### PR TITLE
add adaptive trigger support & add adaptive trigger example on pico e…

### DIFF
--- a/src/components/bluepad32/include/parser/uni_hid_parser.h
+++ b/src/components/bluepad32/include/parser/uni_hid_parser.h
@@ -38,6 +38,7 @@ typedef void (*report_parse_feature_report_fn_t)(struct uni_hid_device_s* d,
                                                  uint16_t report_len);
 typedef void (*report_set_player_leds_fn_t)(struct uni_hid_device_s* d, uint8_t leds);
 typedef void (*report_set_lightbar_color_fn_t)(struct uni_hid_device_s* d, uint8_t r, uint8_t g, uint8_t b);
+typedef void (*report_set_trigger_effect_fn_t)(struct uni_hid_device_s* d, const uint8_t trigger_type, const uint8_t trigger_effect[11]);
 typedef void (*report_set_rumble_fn_t)(struct uni_hid_device_s* d, uint8_t force, uint8_t duration);
 typedef void (*report_device_dump_t)(struct uni_hid_device_s* d);
 
@@ -57,6 +58,8 @@ typedef struct {
     report_set_player_leds_fn_t set_player_leds;
     // If implemented, changes the lightbar color (e.g.: in DS4 and DualSense)
     report_set_lightbar_color_fn_t set_lightbar_color;
+    // If implemented, applies trigger effects on triggers (e.g.: in DS5)
+    report_set_trigger_effect_fn_t set_trigger_effect;
     // If implemented, activates rumble in the gamepad
     report_set_rumble_fn_t set_rumble;
     // If implemented, it dumps device info

--- a/src/components/bluepad32/include/parser/uni_hid_parser_ds5.h
+++ b/src/components/bluepad32/include/parser/uni_hid_parser_ds5.h
@@ -9,6 +9,29 @@
 
 #include "parser/uni_hid_parser.h"
 
+/******* Dualsense(DS5) Adaptive Trigger Effects - Start *******/
+// Built with help of https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db, licensed under MIT License
+// Currently only implemented ones marked as "safe"
+
+// Switches trigger effect off
+void ds5_generate_trigger_effect_off(uint8_t effect[11]);
+
+// position: should between 0 and 9, inclusive
+// strength: should between 0 and 8, inclusive
+void ds5_generate_trigger_effect_feedback(uint8_t effect[11], const uint8_t position, const uint8_t strength);
+
+// start_position: should be between 2 and 7, inclusive
+// end_position: should be between start_position + 1 and 8, inclusive
+// strength: should be between 0 and 8, inclusive
+void ds5_generate_trigger_effect_weapon(uint8_t effect[11], const uint8_t start_position, const uint8_t end_position, const uint8_t strength);
+
+// Warning! Not to be confused with gamepad rumble feature. This is an adaptive trigger effect!
+// position: should be between 0 and 9, inclusive
+// amplitude: should be between 0 and 8, inclusive
+// frequency: should be in Hz
+void ds5_generate_trigger_effect_vibration(uint8_t effect[11], const uint8_t position, const uint8_t amplitude, const uint8_t frequency);
+/******* Dualsense(DS5) Adaptive Trigger Effects - End *******/
+
 // For DualSense gamepads
 void uni_hid_parser_ds5_setup(struct uni_hid_device_s* d);
 void uni_hid_parser_ds5_init_report(struct uni_hid_device_s* d);
@@ -16,6 +39,7 @@ void uni_hid_parser_ds5_parse_input_report(struct uni_hid_device_s* d, const uin
 void uni_hid_parser_ds5_parse_feature_report(struct uni_hid_device_s* d, const uint8_t* report, uint16_t len);
 void uni_hid_parser_ds5_set_player_leds(struct uni_hid_device_s* d, uint8_t value);
 void uni_hid_parser_ds5_set_lightbar_color(struct uni_hid_device_s* d, uint8_t r, uint8_t g, uint8_t b);
+void uni_hid_parser_ds5_set_trigger_effect(struct uni_hid_device_s* d, const uint8_t trigger_type, const uint8_t trigger_effect[11]);
 void uni_hid_parser_ds5_set_rumble(struct uni_hid_device_s* d, uint8_t value, uint8_t duration);
 void uni_hid_parser_ds5_device_dump(struct uni_hid_device_s* d);
 #endif  // UNI_HID_PARSER_DS5_H

--- a/src/components/bluepad32/parser/uni_hid_parser_ds5.c
+++ b/src/components/bluepad32/parser/uni_hid_parser_ds5.c
@@ -208,7 +208,7 @@ static void ds5_parse_mouse(uni_hid_device_t* d, const uint8_t* report, uint16_t
 void ds5_generate_trigger_effect_off(uint8_t effect[11]) {
     effect[0] = 0x05;
 
-    for (uint8_t i = 1; i < 8; i++)
+    for (uint8_t i = 1; i < 11; i++)
         effect[i] = 0x0;
 }
 

--- a/src/components/bluepad32/parser/uni_hid_parser_ds5.c
+++ b/src/components/bluepad32/parser/uni_hid_parser_ds5.c
@@ -40,6 +40,9 @@ enum {
     DS5_FLAG1_LIGHTBAR = BIT(2),
     DS5_FLAG1_PLAYER_LED = BIT(4),
 
+    DS5_FLAG0_LEFT_FFB = BIT(3),
+    DS5_FLAG0_RIGHT_FFB = BIT(2),
+
     // Values for flag 2
     DS5_FLAG2_LIGHTBAR_SETUP_CONTROL_ENABLE = BIT(1),
 
@@ -102,7 +105,9 @@ typedef struct __attribute((packed)) {
     uint8_t mute_button_led;
 
     uint8_t power_save_control;
-    uint8_t reserved2[28];
+    uint8_t right_trigger_ffb[11];
+    uint8_t left_trigger_ffb[11];
+    uint8_t reserved2[6];
 
     /* LEDs and lightbar */
     uint8_t valid_flag2;
@@ -194,6 +199,94 @@ static void ds5_request_firmware_version_report(uni_hid_device_t* d);
 static void ds5_request_calibration_report(uni_hid_device_t* d);
 static void ds5_set_rumble_off(btstack_timer_source_t* ts);
 static void ds5_parse_mouse(uni_hid_device_t* d, const uint8_t* report, uint16_t len);
+
+
+/******* Dualsense(DS5) Adaptive Trigger Effects - Start *******/
+// Built with help of https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db, licensed under MIT License
+
+// Switches trigger effect off
+void ds5_generate_trigger_effect_off(uint8_t effect[11]) {
+    effect[0] = 0x05;
+
+    for (uint8_t i = 1; i < 8; i++)
+        effect[i] = 0x0;
+}
+
+// position: should between 0 and 9, inclusive
+// strength: should between 0 and 8, inclusive
+void ds5_generate_trigger_effect_feedback(uint8_t effect[11], const uint8_t position, const uint8_t strength) {
+    assert(0 <= position && position <= 9);
+    assert(0 <= strength && strength <= 8);
+
+    effect[0] = 0x21;
+
+    uint8_t force_value = (strength - 1) & 0x07; // only 3 bits used
+    uint32_t force_zones = 0;
+    uint16_t active_zones = 0;
+
+    for(uint8_t i = position; i <= 9; i++) {
+        force_zones |= force_value << (i * 3); // each force value occupies 3 bits x 10 zones
+        active_zones |= (uint16_t)(1 << i); // zone mask
+    }
+
+    effect[1] = (active_zones >> 0) & 0xFF;
+    effect[2] = (active_zones >> 8) & 0xFF;
+    effect[3] = (force_zones >> 0) & 0xFF;
+    effect[4] = (force_zones >> 8) & 0xFF;
+    effect[5] = (force_zones >> 16) & 0xFF;
+    effect[6] = (force_zones >> 24) & 0xFF;
+    effect[7] = effect[8] = effect[9] = effect[10] = 0x00;
+}
+
+// start_position: should be between 2 and 7, inclusive
+// end_position: should be between start_position + 1 and 8, inclusive
+// strength: should be between 0 and 8, inclusive
+void ds5_generate_trigger_effect_weapon(uint8_t effect[11], const uint8_t start_position, const uint8_t end_position, const uint8_t strength) {
+    assert(2 <= start_position && start_position <= 7);
+    assert(start_position + 1 <= end_position && end_position <= 8);
+    assert(0 <= strength && strength <= 8);
+
+    effect[0] = 0x25;
+
+    uint16_t start_and_stop_zones = (1 << start_position) | (1 << end_position);
+
+    effect[1] = (start_and_stop_zones >> 0) & 0xFF;
+    effect[2] = (start_and_stop_zones >> 8) & 0xFF;
+    effect[3] = strength - 1;
+    effect[4] = effect[5] = effect[6] = effect[7] = effect[8] = effect[9] = effect[10] = 0x00;
+}
+
+// Warning! Not to be confused with gamepad rumble feature. This is an adaptive trigger effect!
+// position: should be between 0 and 9, inclusive
+// amplitude: should be between 0 and 8, inclusive
+// frequency: should be in Hz
+void ds5_generate_trigger_effect_vibration(uint8_t effect[11], const uint8_t position, const uint8_t amplitude, const uint8_t frequency) {
+    assert(0 <= position && position <= 9);
+    assert(0 <= amplitude && amplitude <= 8);
+
+    effect[0] = 0x26;
+
+    uint8_t strength_value = (amplitude - 1) & 0x07; // only 3 bits used
+    uint32_t amplitude_zones = 0;
+    uint16_t active_zones = 0;
+
+    for(uint8_t i = position; i <= 9; i++) {
+        amplitude_zones |= (uint32_t)strength_value << (i * 3); // each force value occupies 3 bits x 10 zones
+        active_zones |= (uint16_t)(1 << i); // zone mask
+    }
+
+    effect[1] = (active_zones >> 0) & 0xFF;
+    effect[2] = (active_zones >> 8) & 0xFF;
+    effect[3] = (amplitude_zones >> 0) & 0xFF;
+    effect[4] = (amplitude_zones >> 8) & 0xFF;
+    effect[5] = (amplitude_zones >> 16) & 0xFF;
+    effect[6] = (amplitude_zones >> 24) & 0xFF;
+    effect[7] = effect[8] = 0x00;
+    effect[9] = frequency;
+    effect[10] = 0x00;
+}
+/******* Dualsense(DS5) Adaptive Trigger Effects - End *******/
+
 
 void uni_hid_parser_ds5_init_report(uni_hid_device_t* d) {
     uni_controller_t* ctl = &d->controller;
@@ -482,6 +575,25 @@ void uni_hid_parser_ds5_set_lightbar_color(struct uni_hid_device_s* d, uint8_t r
     };
 
     ds5_send_output_report(d, &out);
+}
+
+// trigger_type: 0 if left, 1 if right
+void uni_hid_parser_ds5_set_trigger_effect(struct uni_hid_device_s* d, const uint8_t trigger_type, const uint8_t trigger_effect[11]) {
+    // It should be either left trigger or right trigger.
+    assert(trigger_type == 0 || trigger_type == 1);
+
+    ds5_output_report_t out = {
+        .valid_flag0 =  (trigger_type == 0) ? DS5_FLAG0_LEFT_FFB : DS5_FLAG0_RIGHT_FFB
+    };
+
+    if (trigger_type == 0){
+        memcpy(out.left_trigger_ffb, trigger_effect, sizeof(*trigger_effect) * 11);
+    } else {
+        memcpy(out.right_trigger_ffb, trigger_effect, sizeof(*trigger_effect) * 11);
+    }
+    
+    //logi("Has set valid flag %d, also, %d, and, %d", out.valid_flag0, out.left_trigger_ffb, out.right_trigger_ffb);
+    ds5_send_output_report(d, &out); 
 }
 
 void uni_hid_parser_ds5_set_rumble(struct uni_hid_device_s* d, uint8_t value, uint8_t duration) {

--- a/src/components/bluepad32/uni_hid_device.c
+++ b/src/components/bluepad32/uni_hid_device.c
@@ -648,6 +648,7 @@ void uni_hid_device_guess_controller_type_from_pid_vid(uni_hid_device_t* d) {
             d->report_parser.parse_feature_report = uni_hid_parser_ds5_parse_feature_report;
             d->report_parser.set_player_leds = uni_hid_parser_ds5_set_player_leds;
             d->report_parser.set_lightbar_color = uni_hid_parser_ds5_set_lightbar_color;
+            d->report_parser.set_trigger_effect = uni_hid_parser_ds5_set_trigger_effect;
             d->report_parser.set_rumble = uni_hid_parser_ds5_set_rumble;
             d->report_parser.device_dump = uni_hid_parser_ds5_device_dump;
             logi("Device detected as DualSense: 0x%02x\n", type);


### PR DESCRIPTION
solves https://github.com/ricardoquesada/bluepad32/issues/73
+ added main adaptive trigger functionality
+ added sub example to pico example of dualsense, dpad-left to toggle between 3 effect (actually 4 if you count no-effect) on left trigger, or d-pad right to do the same on right trigger.