### PR TITLE
Add safe platform hook method

### DIFF
--- a/src/components/bluepad32/include/bt/uni_bt.h
+++ b/src/components/bluepad32/include/bt/uni_bt.h
@@ -41,6 +41,8 @@ void uni_bt_enable_new_connections_unsafe(bool enabled);
 bool uni_bt_enable_new_connections_is_enabled(void);
 // Enables the BLE service
 void uni_bt_enable_service_safe(bool enabled);
+// Calls the custom platform hook
+void uni_run_platform_hook_safe(void);
 
 // Disconnects a device
 void uni_bt_disconnect_device_safe(int device_idx);

--- a/src/components/bluepad32/include/platform/uni_platform.h
+++ b/src/components/bluepad32/include/platform/uni_platform.h
@@ -76,6 +76,9 @@ struct uni_platform {
 
     // Register console commands. Optional
     void (*register_console_cmds)(void);
+
+    // Create a hook to run code on the bluetooth core safely.
+    void (*safe_platform_hook)(void);
 };
 
 void uni_platform_init(int argc, const char** argv);


### PR DESCRIPTION
This request adds a few bits of functionality

1) uni_run_platform_hook_safe(void)
This is a safe way to call and execute a function on the bluetooth core. The functionality is provided by the custom platform

2) safe_platform_hook attribute to uni_platform
This is a user-defined method that gets executed when uni_run_platform_hook_safe is called

Why? There's no good way to safely execute custom code on the bluetooth core right now. Things like changing rumble state in real time is a bit convoluted, and requires hooking in to the gamepad update status, which, if the analog sticks haven't moved, rumble just stays on (as an example of an edge case). This allows working around such behavior, but also allows expanding on functionality in other perhaps unthought of manners. 