### PR TITLE
Increasing main task stack for esp32c6 during xbox connection, esp-id…

### DIFF
--- a/examples/esp32/sdkconfig.defaults.esp32c6
+++ b/examples/esp32/sdkconfig.defaults.esp32c6
@@ -1,0 +1,2 @@
+# Increase main task stack size for ESP32C6 build (eg: idf.py set-target esp32c6).
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096


### PR DESCRIPTION
…f v5.3.2

When building: examples/esp32
with: idf.py set-target esp32c6
and esp-idf: commit 9d7f2d69f50d1288526d4f1027108e314e8c879f (HEAD, tag: v5.3.2)

Connecting an xbox controller
Firmware Revision: 5.9.2709.0

Lead to an error of: Guru Meditation Error: Core  0 panic'ed (Stack protection fault

Increasing 'ESP_MAIN_TASK_STATCK_SIZE' to 4096 resolved the issues.
As it's unclear of the scope of the issues (ie if other/all ESP boards are impacted), this adds a target specific fix.  It's possible the the root cause is that the default for 'esp-idf' isn't appropriate when BT LE is in use, although  this addresses the issue that's been observed in this context.