### PR TITLE
fix esp32 example build issue

### DIFF
--- a/src/components/cmd_system/CMakeLists.txt
+++ b/src/components/cmd_system/CMakeLists.txt
@@ -1,5 +1,5 @@
 if("${IDF_VERSION_MAJOR}" GREATER_EQUAL 5)
 idf_component_register(SRCS "cmd_system.c"
                     INCLUDE_DIRS .
-                    REQUIRES console spi_flash driver)
+                    REQUIRES console spi_flash driver esp_driver_gpio)
 endif()

--- a/src/components/cmd_system/cmd_system.c
+++ b/src/components/cmd_system/cmd_system.c
@@ -18,6 +18,7 @@
 #include <argtable3/argtable3.h>
 #include <driver/rtc_io.h>
 #include <driver/uart.h>
+#include <driver/gpio.h>
 #include <esp_chip_info.h>
 #include <esp_console.h>
 #include <esp_flash.h>


### PR DESCRIPTION
for `cmd_system.c` `gpio_wakeup_enable` must be included from `driver/gpio.h` as seen in
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#_CPPv418gpio_wakeup_enable10gpio_num_t15gpio_int_type_t

also added `esp_driver_gpio` to `CMakeLists.txt` as instructed in
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html#header-file

esp32 example build process does not work otherwise