### PR TITLE
Fix: Allow HID connection when Device Information Service is missing

### DIFF
--- a/src/components/bluepad32/bt/uni_bt_le.c
+++ b/src/components/bluepad32/bt/uni_bt_le.c
@@ -412,7 +412,28 @@ static void uni_device_information_packet_handler(uint8_t packet_type,
                     device->hids_cid = hids_cid;
                     break;
                 default:
-                    logi("Device Information service client connection failed, error=%#x.\n", status);
+                    logi("Device Information service client connection failed, error=%#x. Continuing to HID.\n",
+                         status);
+                    device = uni_hid_device_get_instance_for_connection_handle(con_handle);
+                    if (!device) {
+                        loge("Invalid device for in GATTSERVICE_SUBEVENT_DEVICE_INFORMATION_DONE");
+                        break;
+                    }
+                    status = hids_client_connect(con_handle, uni_hids_client_packet_handler, HID_PROTOCOL_MODE_REPORT,
+                                                 &hids_cid);
+                    if (status == ERROR_CODE_SUCCESS) {
+                        logi("Using hids_cid=%d\n", hids_cid);
+                        device->hids_cid = hids_cid;
+                        break;
+                    }
+
+                    if (status == ERROR_CODE_COMMAND_DISALLOWED) {
+                        logi("HID client connection already established, ignoring\n");
+                        break;
+                    }
+
+                    // Real failure
+                    logi("HID client connection failed, status=%#x\n", status);
                     hog_disconnect(con_handle);
                     break;
             }


### PR DESCRIPTION
DIS is optional on many BLE HID devices, especially low-cost devices like mice. 

The current code treats any DIS failure as fatal and drops the connection immediately. That creates an endless reconnect loop, and HID never gets a chance to start.

This patch changes the flow. If DIS fails, we keep going. HID is what matters. I have tested it with crappy Chinese Bluetooth mice that previously couldn't connect. Cheap devices often use tiny microcontrollers with limited resources, so they don't implement DIS.  

I created this PR on the main branch; I'm not sure whether it should go to the main/maintenance branch or the development branch. So use it as a "good to have" feature, given that now it is becoming more popular with keyboards and mice.

My concern about this change is the impact on other devices. A macro to enable/disable the feature could also be a good option. 