### PR TITLE
Fix: Allow HID connection when Device Information Service is missing

### DIFF
--- a/src/components/bluepad32/bt/uni_bt_le.c
+++ b/src/components/bluepad32/bt/uni_bt_le.c
@@ -414,7 +414,32 @@ static void uni_device_information_packet_handler(uint8_t packet_type,
                     device->hids_cid = hids_cid;
                     break;
                 default:
-                    logi("Device Information service client connection failed, error=%#x.\n", status);
+#if UNI_HID_DEVICE_ALLOW_NO_DIS
+                    logi("Device Information service client connection failed, error=%#x. Continuing to HID.\n",
+                         status);
+                    device = uni_hid_device_get_instance_for_connection_handle(con_handle);
+                    if (!device) {
+                        loge("Invalid device for in GATTSERVICE_SUBEVENT_DEVICE_INFORMATION_DONE");
+                        break;
+                    }
+                    status = hids_client_connect(con_handle, uni_hids_client_packet_handler, HID_PROTOCOL_MODE_REPORT,
+                                                 &hids_cid);
+                    if (status == ERROR_CODE_SUCCESS) {
+                        logi("Using hids_cid=%d\n", hids_cid);
+                        device->hids_cid = hids_cid;
+                        break;
+                    }
+
+                    if (status == ERROR_CODE_COMMAND_DISALLOWED) {
+                        logi("HID client connection already established, ignoring\n");
+                        break;
+                    }
+
+                    // Real failure
+                    logi("HID client connection failed, status=%#x\n", status);
+#else
+                    logi("Device Information Service client connection failed, error=%#x. Disconnecting.\n", status);
+#endif
                     hog_disconnect(con_handle);
                     break;
             }

--- a/src/components/bluepad32/controller/uni_controller_type.c
+++ b/src/components/bluepad32/controller/uni_controller_type.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "uni_hid_device.h"
 #include "controller/uni_controller_list.h"
 #include "sdkconfig.h"
 #include "uni_common.h"

--- a/src/components/bluepad32/include/controller/uni_controller_list.h
+++ b/src/components/bluepad32/include/controller/uni_controller_list.h
@@ -451,7 +451,9 @@ static const uni_controller_description_t arrControllers[] = {
 	{ MAKE_CONTROLLER_ID( 0x146b, 0x0611 ), k_eControllerType_XBoxOneController, NULL },	// Xbox Controller Mode for NACON Revolution 3
 
 	// These have been added via Minidump for unrecognized Xinput controller assert
+#if !UNI_HID_DEVICE_ALLOW_NO_DIS
 	{ MAKE_CONTROLLER_ID( 0x0000, 0x0000 ), k_eControllerType_XBox360Controller, NULL },	// Unknown Controller
+#endif
 	{ MAKE_CONTROLLER_ID( 0x045e, 0x02a2 ), k_eControllerType_XBox360Controller, NULL },	// Unknown Controller - Microsoft VID
 	{ MAKE_CONTROLLER_ID( 0x0e6f, 0x1414 ), k_eControllerType_XBox360Controller, NULL },	// Unknown Controller
 	{ MAKE_CONTROLLER_ID( 0x0e6f, 0x0159 ), k_eControllerType_XBox360Controller, NULL },	// Unknown Controller

--- a/src/components/bluepad32/include/uni_hid_device.h
+++ b/src/components/bluepad32/include/uni_hid_device.h
@@ -39,6 +39,14 @@
 #define HID_DEVICE_MAX_PLATFORM_DATA 256  ///< Max size for platform-specific data.
 
 /**
+ * @brief Allow HID devices that don't expose the Device Information Service (DIS, 0x180A).
+ *
+ * Set to 1 to accept devices without DIS and continue to HID.
+ * Set to 0 to reject devices without DIS.
+ */
+#define UNI_HID_DEVICE_ALLOW_NO_DIS 1
+
+/**
  * @brief HID_DEVICE_CONNECTION_TIMEOUT_MS includes the time from when the device is created until it is ready.
  */
 #define HID_DEVICE_CONNECTION_TIMEOUT_MS 20000


### PR DESCRIPTION
DIS is optional on many BLE HID devices, especially low-cost peripherals like mice.

The current code treats any DIS failure as fatal and disconnects immediately. In practice, this creates an endless reconnect loop, and HID never gets a chance to start.

This patch changes the flow: if DIS fails, we keep going. HID is what matters. I tested this with low-quality Bluetooth mice that previously could not connect. These devices often use very small microcontrollers with limited resources and simply don’t implement DIS.

This patch differs from the previous PR in two key ways:

1. It adds the compile-time macro `UNI_HID_DEVICE_ALLOW_NO_DIS` to enable/disable this behavior. It is enabled by default.

2. If DIS is missing, the VID/PID values remain `0x0000/0x0000`, which collides with `k_eControllerType_XBox360Controller` in `arrControllers`. To avoid breaking the heuristic controller identification when `UNI_HID_DEVICE_ALLOW_NO_DIS=1`, this entry is removed.
