### PR TITLE
Skip redundant SDP HID query when descriptor is already available

### DIFF
--- a/src/components/bluepad32/controller/uni_controller_type.c
+++ b/src/components/bluepad32/controller/uni_controller_type.c
@@ -26,10 +26,10 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#include "controller/uni_controller_list.h"
 #include "sdkconfig.h"
 #include "uni_common.h"
 #include "uni_hid_device.h"
+#include "controller/uni_controller_list.h" // Import list after UNI_HID_DEVICE_ALLOW_NO_DIS
 #include "uni_log.h"
 
 uni_controller_type_t uni_guess_controller_type(uint16_t vid, uint16_t pid) {

--- a/src/components/bluepad32/uni_hid_device.c
+++ b/src/components/bluepad32/uni_hid_device.c
@@ -928,6 +928,13 @@ bool uni_hid_device_does_require_hid_descriptor(const uni_hid_device_t* d) {
         return false;
     }
 
+    // Some controllers (e.g. Xbox variants matched by name) may already provide
+    // a synthetic/known HID descriptor before SDP HID query starts. In that
+    // case, skip the extra SDP HID-descriptor query to avoid getting stuck.
+    if (uni_hid_device_has_hid_descriptor(d)) {
+        return false;
+    }
+
     // If the parser has a "parse_usage" functions, it is safe to assume that a HID descriptor
     // is needed. "Parse_usage" cannot work without a HID descriptor.
     return (d->report_parser.parse_usage != NULL);


### PR DESCRIPTION
## Summary
This PR fixes fake Bluetooth Xbox controllers that connect/authenticate/L2CAP successfully but then stall in SDP HID-descriptor query and get deleted by connection timeout.

## What is the real change
If a HID descriptor is already present (e.g. injected by name-match for Xbox Wireless), Bluepad32 no longer starts an extra SDP HID-descriptor query.

## Why we are doing this
Some cheap and dirty gamepads ($3-$5 in some marketplaces) pretend to be Xbox BT variants and expose VID/PID = 0x0000/0x0000 but can still be identified by name and assigned a synthetic HID descriptor.

Before this fix, Bluepad32 still attempted SDP HID query even though it already had a descriptor. On affected devices this query can stall, and the device is later dropped by connection timeout.

## Why this is important
Makes fake Xbox BT pairing/ready flow deterministic on problematic firmwares/clones.

## Validation
Tested with generic "Shanwan" models easy to find in Aliexpress (https://www.aliexpress.com/w/wholesale-shanwan.html ). They must be configured in Xbox 360 mode.