### PR TITLE
Add NES Controller support for Switch parser

### DIFF
--- a/src/components/bluepad32/include/uni_common.h
+++ b/src/components/bluepad32/include/uni_common.h
@@ -213,6 +213,8 @@ extern "C" {
  * Taken FreeBSD code.
  */
 static inline intmax_t mult_frac(intmax_t x, intmax_t multiplier, intmax_t divisor) {
+    if (divisor == 0)
+        return 0;
     intmax_t q = (x / divisor);
     intmax_t r = (x % divisor);
     return (q * multiplier) + ((r * multiplier) / divisor);

--- a/src/components/bluepad32/parser/uni_hid_parser_switch.c
+++ b/src/components/bluepad32/parser/uni_hid_parser_switch.c
@@ -97,6 +97,8 @@ enum switch_controller_types {
     SWITCH_CONTROLLER_TYPE_JCL = 0x01,   // Joy-con left
     SWITCH_CONTROLLER_TYPE_JCR = 0x02,   // Joy-con right
     SWITCH_CONTROLLER_TYPE_PRO = 0x03,   // Pro Controller
+    SWITCH_CONTROLLER_TYPE_NES_L = 0x09,  // NES Controller (Left)
+    SWITCH_CONTROLLER_TYPE_NES_R = 0x0a,  // NES Controller (Right)
     SWITCH_CONTROLLER_TYPE_SNES = 0x0b,  // SNES Controller
 };
 
@@ -872,6 +874,8 @@ static void parse_report_30(struct uni_hid_device_s* d, const uint8_t* report, i
             parse_report_30_joycon_right(d, r);
             break;
         case SWITCH_CONTROLLER_TYPE_PRO:
+        case SWITCH_CONTROLLER_TYPE_NES_L:
+        case SWITCH_CONTROLLER_TYPE_NES_R:
         case SWITCH_CONTROLLER_TYPE_SNES:
             parse_report_30_pro_controller(d, r);
             break;
@@ -880,12 +884,11 @@ static void parse_report_30(struct uni_hid_device_s* d, const uint8_t* report, i
             break;
     }
 
-    // IMU is valid for all 3 types of controllers.
-
     // 3 gyro/accel frames are reported.
     // Different approaches: take the latest one, or average them.
     // We just take the latest one. If it is not accurate enough, we can average them.
-    if (ins->mode == SWITCH_MODE_IMU)
+    // Only parse IMU if mode is set AND calibration divisors are valid (NES has no IMU).
+    if (ins->mode == SWITCH_MODE_IMU && ins->imu_cal_gyro_divisor[0] != 0)
         parse_imu(d, &r->imu[2]);
 }
 


### PR DESCRIPTION
## Summary

The NES Controllers (sold for Nintendo Switch Online) report as `controller_type` 0x09 (Left) and 0x0a (Right) in the device info subcommand reply. These types were unhandled in `uni_hid_parser_switch.c`, which caused:

1. `"Switch: Invalid controller_type: 0x0009"` log message
2. A `Guru Meditation Error: IntegerDivideByZero` crash in `parse_imu()` → `mult_frac()` — NES controllers have no IMU, so the gyro calibration divisors are zero

## Changes

- Add `SWITCH_CONTROLLER_TYPE_NES_L` (0x09) and `SWITCH_CONTROLLER_TYPE_NES_R` (0x0a) to the `switch_controller_types` enum
- Route NES controllers through `parse_report_30_pro_controller` (same button layout as SNES/Pro, minus analog sticks and IMU)
- Guard `parse_imu()` call against zero calibration divisors so controllers without IMU don't crash
- Add defensive zero-check in `mult_frac()` to prevent divide-by-zero from any future unrecognized controller type

## Testing

Tested with both NES Controller (Left) and NES Controller (Right) on ESP32-WROOM-32. All buttons (A, B, D-pad, Start, Select, L, R) register correctly. No crash on connect.