### PR TITLE
fix: restrict BLUEPAD32_USB_CONSOLE_ENABLE to UART primary console

### DIFF
--- a/src/components/bluepad32/Kconfig
+++ b/src/components/bluepad32/Kconfig
@@ -90,10 +90,16 @@ menu "Bluepad32"
     config BLUEPAD32_USB_CONSOLE_ENABLE
         bool "Enable USB Console"
         default  y
-        depends on !ESP_CONSOLE_NONE
+        depends on ESP_CONSOLE_UART
         help
             Enables the USB console.
             User can interact with the Bluepad32 firmware via commands.
+
+            Requires UART as the primary console (ESP_CONSOLE_UART_DEFAULT or
+            ESP_CONSOLE_UART_CUSTOM). USB_SERIAL_JTAG and USB_CDC primary
+            consoles are not supported: the REPL uses the UART-only APIs
+            (esp_console_dev_uart_config_t, esp_console_new_repl_uart()),
+            which are not defined when UART is not the primary console.
 
     config BLUEPAD32_CONSOLE_NVS_COMMAND_ENABLE
         bool "Enable NVS console commands"


### PR DESCRIPTION
## Summary

`BLUEPAD32_USB_CONSOLE_ENABLE` currently depends only on `!ESP_CONSOLE_NONE`, so it stays selectable when `ESP_CONSOLE_USB_SERIAL_JTAG=y` or `ESP_CONSOLE_USB_CDC=y` is the primary console. In that configuration, `uni_console_init()` (and its `register_bluepad32()` helper) fails to compile because it uses UART-only REPL APIs that ESP-IDF only declares when `ESP_CONSOLE_UART` is set:

- `esp_console_dev_uart_config_t` / `ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT()` — guarded by `#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM` in `components/console/esp_console.h`.
- `esp_console_new_repl_uart()` — same gating.

Tighten the Kconfig dependency to `ESP_CONSOLE_UART` so the option cannot be selected in an incompatible configuration, and document the supported primary consoles in the help text.

A working setup remains: UART primary + USB_SERIAL_JTAG as secondary console (`CONFIG_ESP_CONSOLE_UART_DEFAULT=y`, `CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y`).

Fixes #209.

Note: this PR is deliberately Kconfig-only. Adding first-class USB_SERIAL_JTAG REPL support (via `esp_console_new_repl_usb_serial_jtag()`) will be a separate PR since it needs validation on actual JTAG hardware and relaxes the dependency this PR tightens.

BTstack's `btstack_stdio_esp32.c:150` reference to `CONFIG_ESP_CONSOLE_UART_BAUDRATE` is a separate upstream issue in the BTstack submodule and not addressed here.

## Test plan

- [ ] With `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` primary: `BLUEPAD32_USB_CONSOLE_ENABLE` is no longer selectable in `idf.py menuconfig`, and `idf.py -C src build` succeeds on `esp32s3`.
- [ ] With `CONFIG_ESP_CONSOLE_UART_DEFAULT=y` primary: `BLUEPAD32_USB_CONSOLE_ENABLE=y` continues to build and the REPL works on `esp32` and `esp32s3`.
- [ ] `CONFIG_ESP_CONSOLE_UART_DEFAULT=y` + `CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y`: builds and REPL works on both channels.
- [ ] `src/sdkconfig.ci.plat_*` CI configs continue to pass.