### PR TITLE
feat: support USB_SERIAL_JTAG primary console for REPL

### DIFF
--- a/src/components/bluepad32/Kconfig
+++ b/src/components/bluepad32/Kconfig
@@ -90,10 +90,16 @@ menu "Bluepad32"
     config BLUEPAD32_USB_CONSOLE_ENABLE
         bool "Enable USB Console"
         default  y
-        depends on !ESP_CONSOLE_NONE
+        depends on ESP_CONSOLE_UART
         help
             Enables the USB console.
             User can interact with the Bluepad32 firmware via commands.
+
+            Requires UART as the primary console (ESP_CONSOLE_UART_DEFAULT or
+            ESP_CONSOLE_UART_CUSTOM). USB_SERIAL_JTAG and USB_CDC primary
+            consoles are not supported: the REPL uses the UART-only APIs
+            (esp_console_dev_uart_config_t, esp_console_new_repl_uart()),
+            which are not defined when UART is not the primary console.
 
     config BLUEPAD32_CONSOLE_NVS_COMMAND_ENABLE
         bool "Enable NVS console commands"

--- a/src/components/bluepad32/Kconfig
+++ b/src/components/bluepad32/Kconfig
@@ -90,16 +90,14 @@ menu "Bluepad32"
     config BLUEPAD32_USB_CONSOLE_ENABLE
         bool "Enable USB Console"
         default  y
-        depends on ESP_CONSOLE_UART
+        depends on ESP_CONSOLE_UART || ESP_CONSOLE_USB_SERIAL_JTAG
         help
             Enables the USB console.
             User can interact with the Bluepad32 firmware via commands.
 
-            Requires UART as the primary console (ESP_CONSOLE_UART_DEFAULT or
-            ESP_CONSOLE_UART_CUSTOM). USB_SERIAL_JTAG and USB_CDC primary
-            consoles are not supported: the REPL uses the UART-only APIs
-            (esp_console_dev_uart_config_t, esp_console_new_repl_uart()),
-            which are not defined when UART is not the primary console.
+            Supports UART (ESP_CONSOLE_UART_DEFAULT / ESP_CONSOLE_UART_CUSTOM)
+            and USB_SERIAL_JTAG as the primary console. USB_CDC primary console
+            is not supported by the underlying ESP-IDF REPL helpers.
 
     config BLUEPAD32_CONSOLE_NVS_COMMAND_ENABLE
         bool "Enable NVS console commands"

--- a/src/components/bluepad32/arch/uni_console_esp32.c
+++ b/src/components/bluepad32/arch/uni_console_esp32.c
@@ -551,7 +551,13 @@ void uni_console_init(void) {
 #ifdef CONFIG_BLUEPAD32_USB_CONSOLE_ENABLE
     esp_console_repl_t* repl = NULL;
     esp_console_repl_config_t repl_config = ESP_CONSOLE_REPL_CONFIG_DEFAULT();
+#if CONFIG_ESP_CONSOLE_UART
     esp_console_dev_uart_config_t uart_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
+#elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    esp_console_dev_usb_serial_jtag_config_t jtag_config = ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
+#else
+#error "BLUEPAD32_USB_CONSOLE_ENABLE requires ESP_CONSOLE_UART or ESP_CONSOLE_USB_SERIAL_JTAG as the primary console"
+#endif
     /* Prompt to be printed before each line.
      * This can be customized, made dynamic, etc.
      */
@@ -579,7 +585,11 @@ void uni_console_init(void) {
     if (uni_get_platform()->register_console_cmds)
         uni_get_platform()->register_console_cmds();
 
+#if CONFIG_ESP_CONSOLE_UART
     ESP_ERROR_CHECK(esp_console_new_repl_uart(&uart_config, &repl_config, &repl));
+#elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&jtag_config, &repl_config, &repl));
+#endif
 
     ESP_ERROR_CHECK(esp_console_start_repl(repl));
 


### PR DESCRIPTION
## Summary

Adds first-class support for `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` as the primary console for the Bluepad32 REPL. When that path is active, `uni_console_init()` uses `esp_console_new_repl_usb_serial_jtag()` with `esp_console_dev_usb_serial_jtag_config_t`; the existing UART REPL path is preserved under `#if CONFIG_ESP_CONSOLE_UART`.

Motivating use case: ESP32-S3 / ESP32-C3 / ESP32-C6 boards whose only exposed serial interface is native USB (e.g. Waveshare ESP32-S3-Zero) can now use `BLUEPAD32_USB_CONSOLE_ENABLE=y` without an external UART bridge.

Related to #209 (the compile failure reported there is fixed by #210; this PR adds the feature that makes USB_SERIAL_JTAG a supported primary console rather than just a non-selectable one).

### Depends on

- #210 — relaxes the Kconfig dependency that PR tightens (`depends on ESP_CONSOLE_UART` → `depends on ESP_CONSOLE_UART || ESP_CONSOLE_USB_SERIAL_JTAG`). Until #210 merges, this PR's diff will show two commits.

### Not in this PR

- USB_CDC primary console — ESP-IDF does not expose a matching `esp_console_new_repl_*` helper; still unsupported.
- BTstack submodule `btstack_stdio_esp32.c:150` `CONFIG_ESP_CONSOLE_UART_BAUDRATE` reference — separate upstream issue.

## Test plan

- [ ] `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` primary on ESP32-S3: `idf.py -C src build` succeeds; REPL accepts commands over USB-JTAG; `list_devices`, `help`, and at least one Bluepad32 command round-trip.
- [ ] `CONFIG_ESP_CONSOLE_UART_DEFAULT=y` primary (existing default): no regression on ESP32 and ESP32-S3.
- [ ] `CONFIG_ESP_CONSOLE_UART_DEFAULT=y` + `CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y`: UART REPL continues to work; USB-JTAG acts as secondary log channel.
- [ ] `CONFIG_ESP_CONSOLE_NONE=y`: `BLUEPAD32_USB_CONSOLE_ENABLE` is unselectable (unchanged behavior).
- [ ] Existing `src/sdkconfig.ci.plat_*` CI configs continue to pass.