### PR TITLE
ds3: match "Sony PLAYSTATION(R)3 Controller" clones

### DIFF
--- a/src/components/bluepad32/parser/uni_hid_parser_ds3.c
+++ b/src/components/bluepad32/parser/uni_hid_parser_ds3.c
@@ -325,6 +325,7 @@ bool uni_hid_parser_ds3_does_name_match(struct uni_hid_device_s* d, const char* 
     // - "PLAYSTATION(R)3 Controller"
     // - "PLAYSTATION(R)3Conteroller-PANHAI"
     // - "PLAYSTATION(R)3Controller-ghic"
+    // - "Sony PLAYSTATION(R)3 Controller"  (clones)
     // - "Navigation Controller"
     uint16_t product_id = DUALSHOCK3_PID;
     if (strcmp("Navigation Controller", name) == 0) {
@@ -335,6 +336,9 @@ bool uni_hid_parser_ds3_does_name_match(struct uni_hid_device_s* d, const char* 
             ds3_instance_t* ins = get_ds3_instance(d);
             ins->clone_controller = true;
         }
+    } else if (strncmp("Sony PLAYSTATION(R)3", name, 20) == 0) {
+        ds3_instance_t* ins = get_ds3_instance(d);
+        ins->clone_controller = true;
     } else {
         return false;
     }


### PR DESCRIPTION
## Summary

Some PS3 clones report a device name with a `Sony ` prefix
(`Sony PLAYSTATION(R)3 Controller`). The existing prefix check in
`uni_hid_parser_ds3_does_name_match()` only accepts names that start
with `PLAYSTATION(R)3`, so these devices fell through to the generic
parser even though they speak the standard PS3 packet format.

This PR adds a second prefix branch for the `Sony `-prefixed form and
flags the device as a clone, so the existing clone code paths apply.

Reported and diagnosed by @painnick in #201, who identified the exact
function to update and the canonical clone name.

Closes #201

## Test plan

- [x] `clang-format --dry-run --Werror` is clean.
- [ ] CI builds (ESP-IDF v4.4 / v5.3 / Pico SDK / Posix) pass.
- [ ] Manual: a clone advertising `Sony PLAYSTATION(R)3 Controller`
      now binds to the DS3 parser instead of the generic one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)