### PR TITLE
fix(ble): guard hids_cid, handle stale HOGP connections, scan idempotency

### DIFF
--- a/src/components/bluepad32/bt/uni_bt_le.c
+++ b/src/components/bluepad32/bt/uni_bt_le.c
@@ -108,9 +108,11 @@ static void hog_disconnect(hci_con_handle_t con_handle) {
 
     device = uni_hid_device_get_instance_for_connection_handle(con_handle);
     if (device) {
-        status = hids_client_disconnect(device->hids_cid);
-        if (status != ERROR_CODE_SUCCESS) {
-            loge("Failed to disconnect HIDS client for hids_cid=%d, status=%d\n", device->hids_cid, status);
+        if (device->hids_cid != 0 && device->hids_cid != 0xffff) {
+            status = hids_client_disconnect(device->hids_cid);
+            if (status != ERROR_CODE_SUCCESS) {
+                loge("Failed to disconnect HIDS client for hids_cid=%d, status=%d\n", device->hids_cid, status);
+            }
         }
         // gap_delete_bonding(0, device->conn.btaddr);
     }
@@ -761,9 +763,17 @@ void uni_bt_le_on_gap_event_advertising_report(const uint8_t* packet, uint16_t s
     ARG_UNUSED(size);
 
     gap_event_advertising_report_get_address(packet, addr);
-    if (uni_hid_device_get_instance_for_address(addr)) {
-        // Ignore, address already found
-        return;
+    uni_hid_device_t* existing = uni_hid_device_get_instance_for_address(addr);
+    if (existing) {
+        if (existing->conn.connected && existing->conn.state == UNI_BT_CONN_STATE_DEVICE_READY) {
+            logi("BLE advertisement from connected device %s; replacing stale connection\n", bd_addr_to_str(addr));
+            uni_hid_device_disconnect(existing);
+            uni_hid_device_delete(existing);
+        } else {
+            // Ignore duplicate advertisements while the first connection
+            // attempt is still in progress.
+            return;
+        }
     }
 
     adv_event_get_data(packet, &appearance, name);
@@ -927,6 +937,8 @@ void uni_bt_le_setup(void) {
 void uni_bt_le_scan_start(void) {
     if (!ble_enabled)
         return;
+    if (is_scanning)
+        return;
 
     gap_start_scan();
     logi("BLE scan -> 1\n");
@@ -935,6 +947,8 @@ void uni_bt_le_scan_start(void) {
 
 void uni_bt_le_scan_stop(void) {
     if (!ble_enabled)
+        return;
+    if (!is_scanning)
         return;
 
     gap_stop_scan();


### PR DESCRIPTION
## Summary

Three fixes to improve BLE HID-over-GATT (HOGP) reliability, particularly for peripherals that reconnect after unclean disconnections (supervision timeout, power cycle, OTA reset):

1. **Guard `hids_cid` before calling `hids_client_disconnect()`** — When a BLE device disconnects before HIDS service discovery completes, `hids_cid` is 0 or 0xffff. Passing these to `hids_client_disconnect()` causes undefined behavior in BTstack.

2. **Detect stale connections in `uni_bt_le_on_gap_event_advertising_report()`** — When a BLE peripheral resets or disconnects uncleanly, the central may still hold a device entry marked as connected. If the peripheral starts advertising again, the old code silently ignored it ("address already found"), permanently locking out reconnection until reboot. Now: if the existing entry is connected+ready but advertising, tear down the stale entry and allow fresh connection.

3. **Add `is_scanning` guards to `uni_bt_le_scan_start/stop`** — Prevents redundant `gap_start_scan()`/`gap_stop_scan()` calls that can confuse BTstack's internal scanning state machine when called from multiple code paths.

## Context

Discovered while building an ESP32 robot (GATT client via Bluepad32) connecting to an ESP32-S3 BLE HOGP gamepad peripheral. The peripheral periodically loses connection (RF noise, power cycling) and needs to reconnect reliably without requiring a reboot of the central.

Fix 2 is the most impactful — without it, any unclean BLE disconnection permanently prevents reconnection until the central is power-cycled.

## Testing

- Tested on ESP32-WROOM-32D (central, Bluepad32 4.2.0) connecting to ESP32-S3 (peripheral, NimBLE HOGP gamepad)
- Verified reconnection after: supervision timeout, peripheral power cycle, peripheral OTA reset
- Verified no regression with Classic BT gamepads (PS5, Xbox, Switch Pro)

Fixes #166, fixes #159.